### PR TITLE
refactor: remove accessUri property from Input interface

### DIFF
--- a/src/pages/CreateJob.tsx
+++ b/src/pages/CreateJob.tsx
@@ -49,7 +49,6 @@ const CreateJob: React.FC = () => {
         uri: '',
         params: {},
         copyTs: true,
-        accessUri: '',
       }]
     }
   });
@@ -88,7 +87,6 @@ const CreateJob: React.FC = () => {
       uri: '',
       params: {},
       copyTs: true,
-      accessUri: '',
     });
   };
 
@@ -335,18 +333,6 @@ const CreateJob: React.FC = () => {
                       {...register(`inputs.${index}.uri` as const, { required: 'URI is required' })}
                       type="text"
                       placeholder="/path/to/input.mp4"
-                      className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      Access URI
-                    </label>
-                    <input
-                      {...register(`inputs.${index}.accessUri` as const)}
-                      type="text"
-                      placeholder="http://example.com/file.mp4"
                       className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
                     />
                   </div>

--- a/src/pages/JobDetail.tsx
+++ b/src/pages/JobDetail.tsx
@@ -278,9 +278,6 @@ const JobDetail: React.FC = () => {
                     </div>
                     <div className="text-sm text-gray-600 dark:text-gray-400 space-y-1">
                       <p><span className="font-medium">URI:</span> {input.uri}</p>
-                      {input.accessUri && (
-                        <p><span className="font-medium">Access URI:</span> {input.accessUri}</p>
-                      )}
                       {input.seekTo && (
                         <p><span className="font-medium">Seek To:</span> {input.seekTo}s</p>
                       )}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -80,7 +80,6 @@ export interface Input {
   params: Record<string, string>;
   analyzed?: AudioFile | VideoFile | ImageFile | SubtitleFile;
   copyTs: boolean;
-  accessUri: string;
   seekTo?: number;
 }
 


### PR DESCRIPTION
Remove the accessUri field from the Input interface and all related UI components as it is intended for internal use only and should not be exposed in the user interface.